### PR TITLE
Improved Dockerfile to get a small Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
-#openweb/git-sync:0.0.1
-FROM golang:1.6-onbuild
+#openweb/git-sync:0.0.2
+FROM golang:1.9 as builder
+WORKDIR /src
+COPY main.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o git-sync .
+
+FROM alpine/git
+RUN apk --no-cache add ca-certificates
+WORKDIR /bin
+COPY --from=builder /src/git-sync .
 VOLUME ["/git"]
 ENV GIT_SYNC_DEST /git
-ENTRYPOINT ["/go/bin/git-sync"]
+WORKDIR /usr/bin
+ENTRYPOINT ["/bin/git-sync"]

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // git-sync is a command that pull a git repository to a local directory.
 
-package main // import "k8s.io/contrib/git-sync"
+package main
 
 import (
 	"flag"


### PR DESCRIPTION
Using Docker multi-stage builds and "builder pattern" to have a much smaller Docker image.
Original image was ~750MB, new one ~25MB. This is achieved by having a "build" stage which
uses the `golang:1.9` image to build the `git-sync` binary.

This binary is then copied into the stage used when running the docker image.
This stage is based on a very small `alpine/git` base which is just alpine with the `git`
binary.

See: https://docs.docker.com/develop/develop-images/multistage-build/